### PR TITLE
Fixed Uglify.js error (warning)

### DIFF
--- a/app/assets/javascripts/amlsartmarketparticipantfrontend.js
+++ b/app/assets/javascripts/amlsartmarketparticipantfrontend.js
@@ -31,9 +31,7 @@ $(document).ready(function() {
     }
   })
 
-  var cookieData=GOVUK.getCookie("full-width-banner-cookie");
-
- if (cookieData == null) {
+ if (GOVUK.getCookie("full-width-banner-cookie") == null) {
      $("#full-width-banner").addClass("full-width-banner--show");
  }
 


### PR DESCRIPTION
Fixed an error (warning) on project start up:

`[error] WARN: Collapsing variable cookieData [amlsartmarketparticipantfrontend-app.js:239,5]`

Fix is functionally identical.

## Related / Dependant PRs?

## How Has This Been Tested?

Opened project, verified "Help improve GOV.UK" banner still appears and warning doesn't.

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
