### PR TITLE
Remove the date back door for production deploy

### DIFF
--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -98,9 +98,9 @@ trait Constraints {
 
   protected def minDate(minimum: LocalDate, errorKey: String, args: Any*): Constraint[LocalDate] =
     Constraint {
-      // TODO: Remove after 10th January 2020...
-      case date if date.isEqual(LocalDate.of(1905, 4, 11)) =>
-        Valid
+      // TODO: If current date is before the 10th Jan 2020 the this code may be needed as a back door for testing.
+      //case date if date.isEqual(LocalDate.of(1905, 4, 11)) =>
+      //  Valid
       case date if date.isBefore(minimum) =>
         Invalid(errorKey, args: _*)
       case _ =>

--- a/test/forms/mappings/ConstraintsSpec.scala
+++ b/test/forms/mappings/ConstraintsSpec.scala
@@ -196,11 +196,12 @@ class ConstraintsSpec extends WordSpec with MustMatchers with ScalaCheckProperty
       }
     }
 
-    "return Valid for a date 1905-4-11" in {
-      val result = minDate(LocalDate.now(), "error.past", "foo")(LocalDate.of(1905, 4, 11))
-      result mustEqual Valid
-
-    }
+    // TODO: If current date is before the 10th Jan 2020 the this code may be needed as a back door for testing.
+//    "return Valid for a date 1905-4-11" in {
+//      val result = minDate(LocalDate.now(), "error.past", "foo")(LocalDate.of(1905, 4, 11))
+//      result mustEqual Valid
+//
+//    }
 
     "return Invalid for a date before the minimum" in {
 


### PR DESCRIPTION
Remove the date back door for production deploy

## Related / Dependant PRs?

https://github.com/hmrc/amls-acceptance-test/pull/254

## How Has This Been Tested?

Regression Pack

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
