### PR TITLE
Amls 5741 | Removed colon from secondary heading visually hidden text

### DIFF
--- a/app/views/components/page_heading.scala.html
+++ b/app/views/components/page_heading.scala.html
@@ -18,7 +18,7 @@
 
 <div class="page-header">
  <p class="heading-secondary">
-  <span class="visuallyhidden">This section is: </span>
+  <span class="visuallyhidden">This section is </span>
    @messages(pageHeadingKey)
  </p>
 </div>

--- a/release_notes/AMLS-5741.txt
+++ b/release_notes/AMLS-5741.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5741] - 'Removed colon from Thos section is'


### PR DESCRIPTION
This removes colon from secondary headings in whole service. It will improve reading out the heading with JAWS or other similar aids, which before were reading out colon as 'colon'. ex.: This section is colon art market participant.

## Related / Dependant PRs?

- none

## How Has This Been Tested?

- manually

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [x] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [x] Appropriate labels added.
- [x] RELEASE NOTES ADDED.
