### PR TITLE
DLS-6579 [RP] HMRC Mongo library upgrade.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ bin
 *.iws
 package-lock.json
 node_modules/
+.bsp/

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -52,7 +52,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
-play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoModule"
+play.modules.enabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"
 play.modules.enabled += "config.Module"
 
 play.i18n.langs = ["en", "cy"]

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -53,9 +53,6 @@
     <logger name="io.netty.buffer" level="INFO"/>
     <logger name="play.core.netty" level="INFO"/>
 
-    <logger name="uk.gov" level="INFO"/>
-
-    <logger name="reactivemongo.core" level="INFO"/>
     <logger name="akka" level="INFO"/>
     <logger name="play" level="INFO"/>
     <logger name="org.jose4j" level="INFO"/>

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ object AppDependencies {
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"             % "0.73.0",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"             % "0.74.0",
     "uk.gov.hmrc"       %% "logback-json-logger"            % "5.1.0",
     "uk.gov.hmrc"       %% "govuk-template"                 % "5.69.0-play-28",
     "uk.gov.hmrc"       %% "play-ui"                        % "9.6.0-play-28",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,7 +5,7 @@ object AppDependencies {
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "org.reactivemongo" %% "play2-reactivemongo"            % "1.0.4-play28",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"             % "0.73.0",
     "uk.gov.hmrc"       %% "logback-json-logger"            % "5.1.0",
     "uk.gov.hmrc"       %% "govuk-template"                 % "5.69.0-play-28",
     "uk.gov.hmrc"       %% "play-ui"                        % "9.6.0-play-28",


### PR DESCRIPTION
DLS-6579 HMRC Mongo library upgrade.

As this Repo is not using play-reactive mongo library components extensively, its easy to migrate to HMRC Mongo library.

## Checklist

- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Build passing.
- [ ] Unit tests have full coverage.
- [ ] Unit test approach and implementation has been reviewed with QA (testers).
- [ ] Requires acceptance test run.
- [ ] Appropriate labels added.
- [ ] RELEASE NOTES ADDED.
