### PR TITLE
Addressed a11y issue post-migration

### DIFF
--- a/app/views/DateTransactionOverThresholdView.scala.html
+++ b/app/views/DateTransactionOverThresholdView.scala.html
@@ -50,8 +50,7 @@
                     classes = "govuk-fieldset__legend--xl",
                     isPageHeading = true
                 ))
-            )),
-            attributes = Map("pattern" -> "[0-9]*")
+            ))
         ).withFormField(form("value")))
 
         @button("site.continue", "submit")


### PR DESCRIPTION
- Attribute “pattern” not allowed on element “div” at this point --- removed